### PR TITLE
Assign fresh UUID

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "JuliaReachTemplatePkg"
-uuid = "7e933142-fe23-11e8-0e3a-eb85481d2276"
+uuid = "2b714139-d377-45b9-9f15-0355f7430025"
 version = "0.1.0"
 
 [extras]


### PR DESCRIPTION
The current UUID is identical with `MathematicalSets`, which prevents you from having both packages in your registry.
Merged into #9.