### PR TITLE
Fix docs deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ DocMeta.setdocmeta!(JuliaReachTemplatePkg, :DocTestSetup,
                     :(using JuliaReachTemplatePkg); recursive=true)
 
 makedocs(
-    sitename = "JuliaReachTemplatePkg.jl",
+    sitename = "JuliaReachTemplatePkg",
     modules = [JuliaReachTemplatePkg],
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
@@ -17,5 +17,5 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/JuliaReach/JuliaReachTemplatePkg.jl.git"
+    repo = "github.com/JuliaReach/JuliaReachTemplatePkg.git"
 )


### PR DESCRIPTION
Docs deployment fails because the repository does not end in `.jl`.

```
│ - ✔ ENV["GITHUB_REPOSITORY"]="JuliaReach/JuliaReachTemplatePkg" occurs in repo="github.com/JuliaReach/JuliaReachTemplatePkg.jl.git"
...
ERROR: Repository not found.
```